### PR TITLE
fix: widget resize creating multiple cava instances in fallback mode

### DIFF
--- a/package/contents/ui/components/ProcessMonitorFallback.qml
+++ b/package/contents/ui/components/ProcessMonitorFallback.qml
@@ -12,6 +12,7 @@ Item {
     property bool running: stdout !== ""
     property string pid: ""
     property bool isReady: false
+    property bool pendingRestart: false
 
     readonly property string toolsDir: Qt.resolvedUrl("../tools").toString().substring(7) + "/"
     readonly property string commandMonitorTool: "'" + toolsDir + "commandMonitor'"
@@ -55,6 +56,7 @@ Item {
                         root.pid = message.trim().split(" ")[1];
                         logger.debug(`started ${root.monitorCommand} with pid:`, root.pid);
                         root.stderr = "";
+                        root.pendingRestart = false;
                         return;
                     }
                     root.stdout = message.trim().replace(/"/g, "");
@@ -65,6 +67,7 @@ Item {
 
     function start() {
         logger.debug("ProcessMonitorFallback.start()");
+        pendingRestart = true;
         Utils.delay(100, () => {
             isReady = true;
             runCommand.run(root.monitorCommand);
@@ -79,6 +82,8 @@ Item {
     }
 
     function restart() {
+        if (pendingRestart)
+            return;
         logger.debug("ProcessMonitorFallback.restart()");
         stop();
         start();

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -69,9 +69,16 @@ PlasmoidItem {
             return;
         }
         Qt.callLater(() => {
-            logger.debug("barCount:", barCount);
-            cava.barCount = barCount;
+            barCountDebounce.restart();
         });
+    }
+
+    Timer {
+        id: barCountDebounce
+        interval: 50
+        onTriggered: {
+            cava.barCount = main.barCount;
+        }
     }
 
     onEditModeChanged: {


### PR DESCRIPTION
Bring back the check for pending processMonitor restart that was mistakenly removed. Debounce barCount changes to avoid unnecessary ProcessMonitor restarts during widget resize

Partially revert https://github.com/luisbocanegra/kurve/commit/301c9a7dbcad8c413d355bc2c20499f7b0878e49

refs: https://github.com/luisbocanegra/kurve/issues/103 https://github.com/luisbocanegra/kurve/issues/49