### PR TITLE
feat: add option to disable sensitivity and disable it by default

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -25,6 +25,9 @@
     <entry name="autoSensitivity" type="Bool">
       <default>true</default>
     </entry>
+    <entry name="sensitivityEnabled" type="Bool">
+      <default>true</default>
+    </entry>
     <entry name="sensitivity" type="Int">
       <default>100</default>
     </entry>

--- a/package/contents/ui/Cava.qml
+++ b/package/contents/ui/Cava.qml
@@ -9,6 +9,7 @@ Item {
     property int monstercat // boolean
     property int waves // boolean
     property int autoSensitivity // boolean
+    property bool sensitivityEnabled
     property int sensitivity
     property int lowerCutoffFreq
     property int higherCutoffFreq
@@ -44,13 +45,15 @@ Item {
 framerate=${root.framerate}
 bars=${root.barCount}
 autosens=${root.autoSensitivity}
-sensitivity=${root.sensitivity}
 lower_cutoff_freq=${root.lowerCutoffFreq}
 higher_cutoff_freq=${root.higherCutoffFreq}
 sleep_timer=${root.cavaSleepTimer}
-[input]
 `;
 
+        if (root.sensitivityEnabled) {
+            config += `sensitivity=${root.sensitivity}\n`;
+        }
+        config += "[input]\n";
         if (root.inputMethod !== "") {
             config += `method=${root.inputMethod}\n`;
         }

--- a/package/contents/ui/configCava.qml
+++ b/package/contents/ui/configCava.qml
@@ -12,6 +12,7 @@ KCM.SimpleKCM {
     property alias cfg_barCount: barCountSpinbox.value
     property alias cfg_framerate: framerateSpinbox.value
     property alias cfg_autoSensitivity: autoSensitivityCheckbox.checked
+    property alias cfg_sensitivityEnabled: sensitivityEnabled.checked
     property alias cfg_sensitivity: sensitivitySpinbox.value
     property alias cfg_lowerCutoffFreq: lowerCutoffFreqSpinbox.value
     property alias cfg_higherCutoffFreq: higherCutoffFreqSpinbox.value
@@ -101,10 +102,14 @@ KCM.SimpleKCM {
 
             RowLayout {
                 Kirigami.FormData.label: i18n("Sensitivity:")
+                CheckBox {
+                    id: sensitivityEnabled
+                }
                 SpinBox {
                     id: sensitivitySpinbox
                     from: 1
                     to: 999
+                    enabled: sensitivityEnabled.checked
                 }
                 Kirigami.ContextualHelpButton {
                     toolTipText: i18n("Manual sensitivity in %.\nIf autosens is enabled, this will only be the initial value")

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -107,6 +107,7 @@ PlasmoidItem {
         monstercat: Plasmoid.configuration.monstercat
         waves: Plasmoid.configuration.waves
         autoSensitivity: Plasmoid.configuration.autoSensitivity
+        sensitivityEnabled: Plasmoid.configuration.sensitivityEnabled
         sensitivity: Plasmoid.configuration.sensitivity
         lowerCutoffFreq: Plasmoid.configuration.lowerCutoffFreq
         higherCutoffFreq: Plasmoid.configuration.higherCutoffFreq


### PR DESCRIPTION
We enable automatic sensitivity by default

BREAKING CHANGE: If you are using a custom sensitivity value you will need to enable the feature in the feature in the CAVA tab