### PR TITLE
Update README with usage note for kpackagetool6 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Install instructions: <https://software.opensuse.org//download.html?project=home
     `kpackagetool6 -t Plasma/Applet -i package /path/to/downloaded/file.plasmoid`
 
     *NOTE: Replace -i with -u to update instead*
+   
+    *NOTE: `/path/to/downloaded/file.plasmoid` must come directly after `-i` flag. The `package` is a placeholder decribing the thing being installed; Its not meant to be typed literally.*
 
 ### Build from source (With C++ Plugin)
 


### PR DESCRIPTION
Clarified usage note for the kpackagetool6 command, used for manually installing the downloaded plasmoid file.

The command with the 'package' flag doesn't work. In reality, the 'package' work is simply a placeholder; The `-i` flag must be followed by the path to the plasmoid file.

When trying to install via the given command, it doesn't work. But omitting the `package` word/flag does it. I confirmed from the web that the package is simply a placeholder.

I want to propose this change so that it doesn't confuse other users. I'm just a user.

:)